### PR TITLE
Add model persistence and CLI options

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ uses a naive Bayesian classifier to automatically sort new files.
 ## Usage
 
 ```
-python -m fileorganiser <training_root> <incoming_dir> <mapping_file> [--apply]
+python -m fileorganiser <training_root> <incoming_dir> <mapping_file> [--apply] [--save-model <path>] [--load-model <path>]
 ```
 
 - `training_root` - directory that already contains organised folders.
@@ -14,6 +14,9 @@ python -m fileorganiser <training_root> <incoming_dir> <mapping_file> [--apply]
 - `mapping_file` - path to write the predicted file-to-folder mapping.
 - `--apply` - actually move the files after writing the mapping. Without this
   flag the tool only writes the mapping.
+- `--save-model <path>` - save the trained classifier to the given file.
+- `--load-model <path>` - load a previously saved classifier instead of
+  learning from `training_root`.
 
 Example:
 

--- a/fileorganiser/classifier.py
+++ b/fileorganiser/classifier.py
@@ -1,8 +1,9 @@
 import math
 import re
+import pickle
 from collections import Counter
 from pathlib import Path
-from typing import Dict, Iterable, List
+from typing import Dict, Iterable, List, Union
 
 class NaiveBayesFileClassifier:
     """Simple multinomial Naive Bayes classifier for file names."""
@@ -46,3 +47,17 @@ class NaiveBayesFileClassifier:
                 best_cls = cls
         assert best_cls is not None
         return best_cls
+
+    def save(self, path: Union[str, Path]) -> None:
+        """Serialize the classifier to the given file."""
+        with Path(path).open("wb") as f:
+            pickle.dump(self, f)
+
+    @classmethod
+    def load(cls, path: Union[str, Path]) -> "NaiveBayesFileClassifier":
+        """Load a classifier previously saved with :meth:`save`."""
+        with Path(path).open("rb") as f:
+            obj = pickle.load(f)
+        if not isinstance(obj, cls):
+            raise TypeError("File does not contain a NaiveBayesFileClassifier")
+        return obj

--- a/fileorganiser/organizer.py
+++ b/fileorganiser/organizer.py
@@ -51,9 +51,16 @@ def main(argv: list[str] | None = None) -> None:
     parser.add_argument("incoming_dir", type=Path)
     parser.add_argument("mapping_file", type=Path)
     parser.add_argument("--apply", action="store_true", help="move files")
+    parser.add_argument("--save-model", type=Path, help="path to save trained classifier")
+    parser.add_argument("--load-model", type=Path, help="load classifier from file")
     args = parser.parse_args(argv)
 
-    clf = learn_structure(args.training_root)
+    if args.load_model:
+        clf = NaiveBayesFileClassifier.load(args.load_model)
+    else:
+        clf = learn_structure(args.training_root)
+        if args.save_model:
+            clf.save(args.save_model)
     mapping = classify_files(clf, args.incoming_dir)
     write_mapping(mapping, args.mapping_file)
     if args.apply:

--- a/tests/test_organizer.py
+++ b/tests/test_organizer.py
@@ -1,5 +1,8 @@
 from pathlib import Path
+import sys
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 from fileorganiser.organizer import learn_structure, classify_files
+from fileorganiser.classifier import NaiveBayesFileClassifier
 
 
 def test_classify(tmp_path: Path) -> None:
@@ -29,3 +32,29 @@ def test_classify(tmp_path: Path) -> None:
     assert mapping["notes.txt"] == "docs"
     assert mapping["photo.jpg"] == "images"
     assert mapping["script.py"] == "code"
+
+
+def test_save_and_load(tmp_path: Path) -> None:
+    root = tmp_path / "root"
+    docs = root / "docs"
+    images = root / "images"
+    docs.mkdir(parents=True)
+    images.mkdir()
+    (docs / "a.txt").write_text("sample")
+    (docs / "b.txt").write_text("sample")
+    (images / "x.jpg").write_text("sample")
+
+    model = learn_structure(root)
+    model_file = tmp_path / "model.pkl"
+    model.save(model_file)
+
+    incoming = tmp_path / "incoming"
+    incoming.mkdir()
+    (incoming / "notes.txt").write_text("sample")
+    (incoming / "photo.jpg").write_text("sample")
+
+    loaded = NaiveBayesFileClassifier.load(model_file)
+    mapping = classify_files(loaded, incoming)
+
+    assert mapping["notes.txt"] == "docs"
+    assert mapping["photo.jpg"] == "images"


### PR DESCRIPTION
## Summary
- enable serializing `NaiveBayesFileClassifier` via `save` and `load`
- extend CLI to save/load models
- document new CLI flags
- add tests covering model persistence

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880bddcd5148322acfbc38ef579b259