### PR TITLE
Add simple progress reporting during scanning and training

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@ The classifier analyses the contents of files (including common Office
 formats such as Word, Excel, PowerPoint and PDF) and works with
 nested folder structures.
 
+Progress updates are printed to stderr every 100 files while scanning and
+training. This keeps output manageable even for large datasets.
+
 ## Usage
 
 ```

--- a/fileorganiser/organizer.py
+++ b/fileorganiser/organizer.py
@@ -4,17 +4,25 @@ import argparse
 import shutil
 from pathlib import Path
 from typing import Dict
+import sys
 
-from .classifier import NaiveBayesFileClassifier
+from .classifier import NaiveBayesFileClassifier, PROGRESS_INTERVAL
 
 
 def learn_structure(root: Path) -> NaiveBayesFileClassifier:
     """Learn folder structure from a root directory recursively."""
     data: Dict[str, list[Path]] = {}
+    count = 0
     for file in root.rglob("*"):
         if file.is_file():
             rel_folder = str(file.parent.relative_to(root))
             data.setdefault(rel_folder, []).append(file)
+            count += 1
+            if PROGRESS_INTERVAL and count % PROGRESS_INTERVAL == 0:
+                msg = f"Scanning: {count} files processed"
+                print(msg, end="\r", file=sys.stderr, flush=True)
+    if count >= PROGRESS_INTERVAL:
+        print(f"Scanning complete: {count} files found.", file=sys.stderr)
     clf = NaiveBayesFileClassifier()
     clf.fit(data)
     return clf


### PR DESCRIPTION
## Summary
- show progress while scanning files in `learn_structure`
- print training progress and completion in `NaiveBayesFileClassifier.fit`
- document progress behaviour in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688363a4924c8322b7ce5214348b8d19